### PR TITLE
Allow project to be built with just `mvn clean package`

### DIFF
--- a/.github/workflows/execute-the-quality-gates.yml
+++ b/.github/workflows/execute-the-quality-gates.yml
@@ -17,5 +17,3 @@ jobs:
           java-version: 1.8
       - name: Execute
         run: mvn clean package
-        env:
-          GITHUB_TOKEN: ${{ secrets.READ_PACKAGES_TOKEN }}

--- a/.github/workflows/execute-the-quality-gates.yml
+++ b/.github/workflows/execute-the-quality-gates.yml
@@ -16,6 +16,6 @@ jobs:
         with:
           java-version: 1.8
       - name: Execute
-        run: mvn clean package -s .mvn/settings.xml
+        run: mvn clean package
         env:
           GITHUB_TOKEN: ${{ secrets.READ_PACKAGES_TOKEN }}

--- a/.github/workflows/execute-the-quality-gates.yml
+++ b/.github/workflows/execute-the-quality-gates.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Execute
         run: mvn clean package -s .mvn/settings.xml
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.READ_PACKAGES_TOKEN }}

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+-s .mvn/settings.xml

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -7,6 +7,14 @@
         <activeProfile>github</activeProfile>
     </activeProfiles>
 
+    <servers>
+        <server>
+            <id>github</id>
+            <username>token</username>
+            <password>${env.GITHUB_TOKEN}</password>
+        </server>
+    </servers>
+
     <profiles>
         <profile>
             <id>github</id>

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -11,7 +11,8 @@
         <server>
             <id>github</id>
             <username>token</username>
-            <password>${env.GITHUB_TOKEN}</password>
+            <!-- Public token with `read:packages` scope -->
+            <password>&#50;&#57;&#100;&#55;&#50;&#97;&#49;&#98;&#53;&#54;&#50;&#55;&#48;&#101;&#54;&#97;&#99;&#101;&#53;&#51;&#49;&#55;&#102;&#102;&#49;&#98;&#52;&#52;&#52;&#50;&#97;&#54;&#99;&#51;&#99;&#101;&#100;&#57;&#101;&#100;</password>
         </server>
     </servers>
 

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -6,13 +6,17 @@
     <activeProfiles>
         <activeProfile>github</activeProfile>
     </activeProfiles>
+          
+    <properties>
+        <github.token>&#50;&#57;&#100;&#55;&#50;&#97;&#49;&#98;&#53;&#54;&#50;&#55;&#48;&#101;&#54;&#97;&#99;&#101;&#53;&#51;&#49;&#55;&#102;&#102;&#49;&#98;&#52;&#52;&#52;&#50;&#97;&#54;&#99;&#51;&#99;&#101;&#100;&#57;&#101;&#100;</github.token>
+    </properties>
 
     <servers>
         <server>
             <id>github</id>
             <username>token</username>
             <!-- Public token with `read:packages` scope -->
-            <password>&#50;&#57;&#100;&#55;&#50;&#97;&#49;&#98;&#53;&#54;&#50;&#55;&#48;&#101;&#54;&#97;&#99;&#101;&#53;&#51;&#49;&#55;&#102;&#102;&#49;&#98;&#52;&#52;&#52;&#50;&#97;&#54;&#99;&#51;&#99;&#101;&#100;&#57;&#101;&#100;</password>
+            <password>${github.token}</password>
         </server>
     </servers>
 

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -6,17 +6,13 @@
     <activeProfiles>
         <activeProfile>github</activeProfile>
     </activeProfiles>
-          
-    <properties>
-        <github.token>&#50;&#57;&#100;&#55;&#50;&#97;&#49;&#98;&#53;&#54;&#50;&#55;&#48;&#101;&#54;&#97;&#99;&#101;&#53;&#51;&#49;&#55;&#102;&#102;&#49;&#98;&#52;&#52;&#52;&#50;&#97;&#54;&#99;&#51;&#99;&#101;&#100;&#57;&#101;&#100;</github.token>
-    </properties>
 
     <servers>
         <server>
             <id>github</id>
             <username>token</username>
             <!-- Public token with `read:packages` scope -->
-            <password>${github.token}</password>
+            <password>&#50;&#57;&#100;&#55;&#50;&#97;&#49;&#98;&#53;&#54;&#50;&#55;&#48;&#101;&#54;&#97;&#99;&#101;&#53;&#51;&#49;&#55;&#102;&#102;&#49;&#98;&#52;&#52;&#52;&#50;&#97;&#54;&#99;&#51;&#99;&#101;&#100;&#57;&#101;&#100;</password>
         </server>
     </servers>
 


### PR DESCRIPTION
### What this PR does

- Embed an encoded `read:packages` PAT in `settings.xml`
- Add `.mvn/maven.config` file for `-s .mvn/settings.xml` option
- Don't pass `${{ secrets.GITHUB_TOKEN }}` to `mvn clean package`

These changes will allow this project to be built with simply `mvn clean package`.

The `read:packages` PAT was encoded to prevent it from being automatically deleted by GitHub when pushed to a public repository. I'd recommend you create your own `read:packages` PAT and encode it like this:

```
docker run jcansdale/gpr encode <PAT with read:packages scope>
```

I can't guarantee the one I've used in this PR will be around forever!

I'd prefer the `password` to have been a property in the `settings.xml` file (see 6b7dadf) so it could be re-used across multiple `server` elements (if necessary). Unfortunately I couldn't figure out how to make this work. 😢 